### PR TITLE
Update items.json

### DIFF
--- a/resources/data/Randomizer/items.json
+++ b/resources/data/Randomizer/items.json
@@ -422,12 +422,6 @@
         "count": 1
     },
     {
-        "id": "FG44",
-        "name": "Crisanta",
-        "type": "Figurine",
-        "count": 1
-    },
-    {
         "id": "FG45",
         "name": "Cobijada Mayor",
         "type": "Figurine",


### PR DESCRIPTION
I removed the next lines as this item creates a softlock with the Sculptor. If you give `QI71 Remembrance of Crisanta` (Eviterno's reward), after getting `FG44 Crisanta`, the Scultor gives nothing and you just can't move.

`    {
        "id": "FG44",
        "name": "Crisanta",
        "type": "Figurine",
        "count": 1
    },`

Yeah, I made a big mistake in the doc XD